### PR TITLE
Fix bind path to htmldoc.

### DIFF
--- a/archmage/arch.conf
+++ b/archmage/arch.conf
@@ -7,7 +7,7 @@ templates_dir = pkg_resources.resource_filename('archmage', 'templates/')
 # Directory with icons
 icons_dir = join(templates_dir, 'icons')
 
-# List of auxiliary files, stored inside CHM file. 
+# List of auxiliary files, stored inside CHM file.
 # Those files would not be extracted.
 auxes = ('/#IDXHDR', '/#ITBITS', '/#STRINGS', '/#SYSTEM', '/#TOPICS',
          '/#URLSTR', '/#URLTBL', '/#WINDOWS', '/$FIftiMain', '/$OBJINST',
@@ -31,30 +31,30 @@ fs_encoding = 'utf-8'
 # If your filesystem is case-sensitive, links in the html can point to
 # files that have differences in the case you need to set
 # filename_case to 1 in that case :-)
-# 
+#
 # Default: filename_case=1
 filename_case = 1
 
 # If you want to add javascript code for restore framing to every
 # page, set addframing.
-# 
+#
 # Default: restore_framing=1
 restore_framing = 1
 
 # Path to htmldoc executable
 #
-htmldoc_exec = '/usr/bin/htmldoc'
+htmldoc_exec = 'htmldoc'
 
 # CHM2TEXT converting. Use following command to convert CHM content to plain
 # text file. Make sure that below apps are available on your system.
 #chmtotext = 'lynx -dump -stdin'
 chmtotext = '/usr/bin/elinks -dump'
 
-# CHM2HTML converting. Use following command to convert CHM content to a single 
+# CHM2HTML converting. Use following command to convert CHM content to a single
 # HTML file. Make sure that htmldoc is available on your system.
 chmtohtml = '-t html -f "%(output)s" --book %(toc)s --no-numbered --toctitle "Table of Contents" --title --linkstyle underline --fontsize 11.0 --fontspacing 1.2 --headingfont Helvetica --bodyfont Times --headfootsize 11.0 --headfootfont Helvetica --charset iso-8859-1 --browserwidth 680 --no-strict --no-overflow --quiet'
 
-# CHM2PDF converting. Use following command to convert CHM content to a single 
+# CHM2PDF converting. Use following command to convert CHM content to a single
 # PDF file. Make sure that htmldoc is available on your system.
 chmtopdf = '-t pdf14 -f "%(output)s" --webpage %(toc)s --no-title --no-numbered --toctitle "Table of Contents" --textcolor "#000000" --linkcolor "#0000ff" --linkstyle plain --size Universal --left 1.00in --right 0.50in --top 0.50in --bottom 0.50in --header .t. --header1 ... --footer h.1 --nup 1 --tocheader .t. --tocfooter ..i --portrait --color --no-pscommands --no-xrxcomments --compression=1 --jpeg=0 --fontsize 11.0 --fontspacing 1.2 --headingfont Helvetica --bodyfont Times --headfootsize 11.0 --headfootfont Helvetica --charset iso-8859-1 --links --embedfonts --pagemode outline --pagelayout single --firstpage c1 --pageeffect none --pageduration 10 --effectduration 1.0 --no-encryption --permissions all  --owner-password ""  --user-password "" --browserwidth 680 --no-strict --no-overflow --quiet'
 


### PR DESCRIPTION
Path variables are defined when the terminal is started and depend on various system configurations, the path to the binary may be different. In case of compilation htmldoc for Linux, the binary will be in /local/, not to mention macOS.